### PR TITLE
feat: add GoatCounter script for analytics tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -24,6 +25,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+      <Script 
+        data-goatcounter="https://ishita.goatcounter.com/count"
+        src="//gc.zgo.at/count.js"
+        strategy="afterInteractive"
+        async
+      />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
Add GoatCounter analytics script for basic web analytics. 

Add a simple script to the root layout so that it's applied to all pages.

I’m thinking about evolving this site into a digital garden someday.
While I’m still cautious about my digital footprint, it feels useful to at least track whether people are visiting and what content draws them. This basic analytics setup is a gentle first step in that direction.