### PR TITLE
fix: prevent mobile background resizing by applying bg-fixed only on md+

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <div className="font-body grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
       <div
         aria-hidden="true"
-        className="fixed inset-0 -z-10 bg-[url('/cats_bg.jpg')] bg-cover bg-[right_80%] md:bg-bottom dark:opacity-20"
+        className="inset-0 -z-10 bg-[url('/cats_bg.jpg')] bg-cover bg-[right_80%] md:bg-bottom dark:opacity-20 md:fixed"
       ></div>
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <div className="flex flex-col gap-8 max-w-2xl">


### PR DESCRIPTION
Fix weird behaviour happening on mobile where the image resizes on scrolling.

This is cause by how handle viewport height changes with bg-fixed. So, scope bg-fixed to md screens and up.